### PR TITLE
Remove config log + headers defaults

### DIFF
--- a/bin/generate-schema-config
+++ b/bin/generate-schema-config
@@ -43,8 +43,6 @@ introspection.then((introspection) => {
     ),
   };
 
-  console.log(JSON.stringify(json, null, 2));
-
   fs.writeFileSync(
     path.join(cwd, distPath),
     JSON.stringify(json, null, 2),

--- a/src/client.ts
+++ b/src/client.ts
@@ -137,7 +137,13 @@ export class Client {
 
   constructor(config: ClientConfig) {
     this.url = config.url;
-    this.headers = config.headers ?? { "Content-Type": "application/json" };
+
+    this.headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...config.headers,
+    };
+
     this.schemaConfig = config.schemaConfig;
     this.cache = new ClientCache(config.schemaConfig);
     this.makeRequest = config.makeRequest ?? defaultMakeRequest;


### PR DESCRIPTION
Currently, the command log the full config in the CLI.
This PR removes this behvior. An alternative would be to print a simple "OK" message.

It also provides defaults for `Accept` & `Content-Type` headers (even if the `headers` option is set)